### PR TITLE
Add IgnoreCopDirectives to Infl/SoftLineLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Add `IgnoreCopDirectives` (default `true`) to `Infl/SoftLineLength`
+
 ### Changes
 
 ## 0.0.1 (2017-02-18)

--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ limit.
       SoftLimit: 80
       HardLimit: 120
       AllowedLongLinePercentage: 2
+      IgnoreCopDirectives: true
 
 This would complain about *any* lines which were longer than 120 characters,
 and allow up to 2% of lines in a file to be longer than 80 characters
 before starting to complain about the lines longer that 80 characters.
+
+The `IgnoreCopDirectives` allows us to ignore `# rubocop:enable ...` (or
+`disable`) lines in the count so that we avoid the situation where adding a `#
+rubocop:disable Infl/SoftLineLength` to a file to stop a warning increases the
+line count so you then start getting an `Unnecessary disabling ...` message. The
+name for this option matches the option in recent `Metrics/LineLength` versions.
 
 # Inspiration
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,3 +5,4 @@ Infl/SoftLineLength:
   SoftLimit: 80
   HardLimit: 120
   AllowedLongLinePercentage: 5
+  IgnoreCopDirectives: true

--- a/lib/rubocop/infl/version.rb
+++ b/lib/rubocop/infl/version.rb
@@ -1,5 +1,5 @@
 module Rubocop
   module Infl
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.2.0-dev'.freeze
   end
 end


### PR DESCRIPTION
When wrangling an old code-base it is sometimes easiest to add the check
and put

    # rubocop:disable Infl/SoftLineLength

directives at the top of "bad" files. This allows `rubocop` to check the
project OK and we can deal with the existing long lines at our own pace.

Sometimes the addition of the directive's increasing the line count of
the file by 1 makes the number of long lines sneak in under the
percentage limit, causing `rubocop` to grumble about unnecessary
disablings.

This change allows us to ignore the directive lines from the line count.

The check is naive, but I beleive "good enough".